### PR TITLE
provider,resource_domain: Add a lock for parallel domain operations

### DIFF
--- a/improvmx/provider.go
+++ b/improvmx/provider.go
@@ -1,9 +1,17 @@
 package improvmx
 
 import (
+	"sync"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	improvmxApi "github.com/issyl0/go-improvmx"
 )
+
+type Meta struct {
+	Resource *schema.ResourceData
+	Client   *improvmxApi.Client
+	Mutex    sync.Mutex
+}
 
 func Provider() *schema.Provider {
 	p := &schema.Provider{
@@ -19,6 +27,11 @@ func Provider() *schema.Provider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	token := d.Get("token").(string)
-	return improvmxApi.NewClient(token), nil
+	m := &Meta{
+		Resource: d,
+		Client:   improvmxApi.NewClient(d.Get("token").(string)),
+		Mutex:    sync.Mutex{},
+	}
+
+	return m, nil
 }


### PR DESCRIPTION
- Inspiration for this locking - and learning how to use it - taken from the Helm Terraform provider as that was one of the search results for the "concurrent map writes" error. :heart_eyes:
- Also handle 429s from reading from the ImprovMX API by sleeping for 5 seconds whenever we encounter one (there's no special error message telling us what to do, so that seemed good enough).
- Also only set the Read attributes if we get `resp.Success`, this seems to stop the periodic "new things have to be created despite the fact that they already exist" that happened when the API returned a non-success response and the `resp.Domain` values we were assigning were blank.
- Fixes #1.