### PR TITLE
resource_email_forward: Fix email forward creation operations

### DIFF
--- a/improvmx/resource_email_forward.go
+++ b/improvmx/resource_email_forward.go
@@ -2,11 +2,12 @@ package improvmx
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	improvmxApi "github.com/issyl0/go-improvmx"
 )
 
 func resourceEmailForward() *schema.Resource {
@@ -39,33 +40,62 @@ func resourceEmailForward() *schema.Resource {
 }
 
 func resourceEmailForwardCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*improvmxApi.Client)
-	client.CreateEmailForward(d.Get("domain").(string), d.Get("alias_name").(string), d.Get("destination_email").(string))
+	m := meta.(*Meta)
+	m.Client.CreateEmailForward(d.Get("domain").(string), d.Get("alias_name").(string), d.Get("destination_email").(string))
 
 	return resourceEmailForwardRead(d, meta)
 }
 
 func resourceEmailForwardRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*improvmxApi.Client)
-	resp := client.GetEmailForward(d.Get("domain").(string), d.Get("alias_name").(string))
+	m := meta.(*Meta)
+	m.Mutex.Lock()
+	defer m.Mutex.Unlock()
 
-	d.SetId(strconv.FormatInt(resp.Alias.Id, 10))
-	d.Set("alias_name", resp.Alias.Alias)
-	d.Set("destination_email", resp.Alias.Forward)
+	for {
+		resp := m.Client.GetEmailForward(d.Get("domain").(string), d.Get("alias_name").(string))
 
-	return nil
+		log.Printf("[DEBUG] Got status code %v from ImprovMX API on Read for email_forward %s@%s, success: %v, errors: %v.", resp.Code, d.Get("alias_name").(string), d.Get("domain").(string), resp.Success, resp.Errors)
+
+		if resp.Code == 429 {
+			log.Printf("[DEBUG] Sleeping for 10 seconds to allow rate limit to recover.")
+			time.Sleep(10 * time.Second)
+		}
+
+		if resp.Success {
+			d.SetId(strconv.FormatInt(resp.Alias.Id, 10))
+			d.Set("alias_name", resp.Alias.Alias)
+			d.Set("destination_email", resp.Alias.Forward)
+
+			return nil
+		}
+	}
 }
 
 func resourceEmailForwardUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*improvmxApi.Client)
-	client.UpdateEmailForward(d.Get("domain").(string), d.Get("alias_name").(string), d.Get("destination_email").(string))
+	m := meta.(*Meta)
 
-	return resourceEmailForwardRead(d, meta)
+	for {
+		resp := m.Client.UpdateEmailForward(d.Get("domain").(string), d.Get("alias_name").(string), d.Get("destination_email").(string))
+
+		log.Printf("[DEBUG] Got status code %v from ImprovMX API on Update for email_forward %s@%s, success: %v, errors: %v.", resp.Code, d.Get("domain").(string), d.Get("alias_name").(string), resp.Success, resp.Errors)
+
+		if resp.Code == 429 {
+			log.Printf("[DEBUG] Sleeping for 10 seconds to allow rate limit to recover.")
+			time.Sleep(10 * time.Second)
+		}
+
+		if resp.Success {
+			return resourceEmailForwardRead(d, meta)
+		}
+	}
 }
 
 func resourceEmailForwardDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*improvmxApi.Client)
-	client.DeleteEmailForward(d.Get("domain").(string), d.Get("alias_name").(string))
+	m := meta.(*Meta)
+	m.Mutex.Lock()
+	defer m.Mutex.Unlock()
+
+	m.Client.DeleteEmailForward(d.Get("domain").(string), d.Get("alias_name").(string))
 
 	return nil
 }


### PR DESCRIPTION
- Since 5041c41e589df52a2851dba06e3fb938526e95a0, configuring email forwards have been broken with:

```
panic: interface conversion: interface {} is *improvmx.Meta, not *improvmx.Client

goroutine 22 [running]:
github.com/issyl0/terraform-provider-improvmx/improvmx.resourceEmailForwardCreate(0xc000179000, 0x1765080, 0xc00061e288, 0x0, 0xffffffffffffffff)
	github.com/issyl0/terraform-provider-improvmx/improvmx/resource_email_forward.go:42 +0x25f
```

- I decided to use the same style of handling as in `resource_domain`, by using a mutex lock on read, and doing rate limit debug logging too.
