### PR TITLE
resource_email_forward: Fix importing, set `alias_name` before reading

### DIFF
--- a/improvmx/resource_email_forward.go
+++ b/improvmx/resource_email_forward.go
@@ -119,6 +119,7 @@ func resourceEmailForwardImport(d *schema.ResourceData, meta interface{}) ([]*sc
 
 	d.SetId(parts[1])
 	d.Set("domain", parts[0])
+	d.Set("alias_name", parts[1])
 
 	resourceEmailForwardRead(d, meta)
 


### PR DESCRIPTION
- The post-import plan for an email forward wouldn't come back clean as all the fields weren't set in the state.
