### PR TITLE
Remove default wildcard email forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,14 @@ resource "improvmx_email_forward" "hello" {
   domain            = "example.com"
   alias_name        = "hello"
   destination_email = "me@realdomain.com"
+  depends_on = [improvmx_domain.example]
 }
+
+resource "improvmx_email_forward" "wildcard" {
+  domain            = "example.com"
+  alias_name        = "*"
+  destination_email = "joe@realdomain.com"
+  depends_on = [improvmx_domain.example]
+}
+
 ```

--- a/improvmx/resource_domain.go
+++ b/improvmx/resource_domain.go
@@ -54,7 +54,13 @@ func resourceDomainCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		if resp.Success {
-			return resourceDomainRead(d, meta)
+			resp2 := m.Client.DeleteEmailForward(d.Get("domain").(string), "*")
+			if resp2.Success {
+				return resourceDomainRead(d, meta)
+			}else{
+				return fmt.Errorf("HTTP response code %d, Failed to delete initial wildcard", resp2.Code)
+			}
+		
 		}
 	}
 }


### PR DESCRIPTION
N.B. Potential breaking change if users are using the default created account.

The `resourceDomainCreate` function currently leaves the default wildcard forward rule in place, linked to the default email account. I couldn't find a way to modify the preexisting wildcard forward rule to point to a user defined email address without doing it manually.

This change calls the Delete email forward API immediately following the creation of the domain, leaving it with no forwards configured, allowing user specification of a wildcard/catch-all forward to an email address of their choosing. 

To me, this feels more inline with the declarative syntax of terraform - but would welcome your thoughts! 